### PR TITLE
Fix error logging in command replies

### DIFF
--- a/commands/levels/level.command.js
+++ b/commands/levels/level.command.js
@@ -29,7 +29,7 @@ module.exports = {
       await interaction.reply({
         content: '❌ There was an error fetching your level.',
         flags: MessageFlags.Ephemeral,
-      }).catch(() => {});
+      }).catch(err => errorHandler(err, 'Level Command - reply error'));
     }
   }
 };

--- a/commands/manageChannels.command.js
+++ b/commands/manageChannels.command.js
@@ -1,5 +1,5 @@
 // commands/manageChannels.command.js
-const { SlashCommandBuilder, PermissionsBitField } = require('discord.js'); // Updated import
+const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
 const UserXP = require('../models/UserXP');
 const { MessageFlags } = require('discord.js');
 const errorHandler = require('../utils/errorHandler');
@@ -93,7 +93,7 @@ module.exports = {
       await interaction.reply({
         content: '❌ There was an error managing the excluded channels.',
         flags: MessageFlags.Ephemeral,
-      }).catch(() => {});
+      }).catch(err => errorHandler(err, 'ManageChannels Command - reply error'));
     }
   },
 };

--- a/commands/matchmaking/matchmaking.command.js
+++ b/commands/matchmaking/matchmaking.command.js
@@ -149,7 +149,6 @@ module.exports = {
       // Schedule the lobby start
       scheduler.scheduleLobbyStart(message.id, matchTime, message);
 
-      // Inform user ephemeral
       await interaction.editReply({
         content: '✅ Your matchmaking lobby has been created in #matchmaking!',
         flags: MessageFlags.Ephemeral
@@ -159,7 +158,7 @@ module.exports = {
       await interaction.reply({
         content: '❌ There was an error creating the matchmaking lobby.',
         flags: MessageFlags.Ephemeral,
-      }).catch(() => {});
+      }).catch(err => errorHandler(err, 'Matchmaking Command - reply error'));
     }
   },
 };


### PR DESCRIPTION
## Summary
- log errors when replying in level command
- log errors when replying in manageChannels command
- log errors when replying in matchmaking command
- remove stray inline comments

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68482278568c8322962b428849ae939c