### PR TITLE
Fix Docker tag formatting

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,7 +34,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=,format=short
-            type=ref,event=tag
+            type=semver,pattern={{version}},value=${{ github.ref_name }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ These practices ensure that if you rename or remove a channel, or if you want to
 
 CI/CD and Releases
 
-The repository ships with GitHub Actions that build and publish the Docker image whenever code lands on `main` or when a new release tag is created. Releases are handled by `release-please`, which opens a pull request proposing the next version. Once the release PR is merged, GitHub creates a tag and the Docker workflow publishes images to GHCR with `latest`, the short commit SHA, and the release version. Release-please reads `.release-please-manifest.json` to track package versions, so keep that file in the repo root.
+The repository ships with GitHub Actions that build and publish the Docker image whenever code lands on `main` or when a new release tag is created. Releases are handled by `release-please`, which opens a pull request proposing the next version. Once the release PR is merged, GitHub creates a tag and the Docker workflow publishes images to GHCR with `latest`, the short commit SHA, and the release version number (for example `1.0.1`). Release-please reads `.release-please-manifest.json` to track package versions, so keep that file in the repo root.
 
 
 ---


### PR DESCRIPTION
## Summary
- sanitize Docker tags to use the version number
- document how images are tagged on release

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848256a8e4083228c3a303b16c54072