### PR TITLE
Fix release tag name prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ CI/CD and Releases
 
 The repository ships with GitHub Actions that build and publish the Docker image whenever code lands on `main` or when a new release tag is created. Releases are handled by `release-please`, which opens a pull request proposing the next version. Once the release PR is merged, GitHub creates a tag and the Docker workflow publishes images to GHCR with `latest`, the short commit SHA, and the release version. Release-please reads `.release-please-manifest.json` to track package versions, so keep that file in the repo root.
 
+Release tags follow the classic `vX.Y.Z` format. Downstream jobs, such as the Docker workflow, use that tag directly when naming images.
+
 
 ---
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,6 @@
 {
   "packages": {
     ".": {
-      "package-name": "pedro-bot",
       "release-type": "node",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true


### PR DESCRIPTION
## Summary
- remove the package name from release-please config so tags use the version number only
- note the standard tag format in the release docs

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848256064188322872da396c59cb8bb