### PR TITLE
Fix Docker build triggers

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,18 @@ on:
   push:
     branches:
       - main
+    paths:
+      - Dockerfile
+      - package.json
+      - package-lock.json
+      - index.js
+      - commands/**
+      - services/**
+      - utils/**
+      - config/**
+      - events/**
+      - models/**
+      - buttons/**
   release:
     types: [created]
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ These practices ensure that if you rename or remove a channel, or if you want to
 
 CI/CD and Releases
 
-The repository ships with GitHub Actions that build and publish the Docker image whenever code lands on `main` or when a new release tag is created. Releases are handled by `release-please`, which opens a pull request proposing the next version. Once the release PR is merged, GitHub creates a tag and the Docker workflow publishes images to GHCR with `latest`, the short commit SHA, and the release version number (for example `1.0.1`). Release-please reads `.release-please-manifest.json` to track package versions, so keep that file in the repo root.
+GitHub Actions build and publish the Docker image when application code or build files change on `main`, or when a new release tag is created. Documentation or workflow tweaks won't trigger a new image. Releases are handled by `release-please`, which opens a pull request proposing the next version. Once the release PR is merged, GitHub creates a tag and the Docker workflow publishes images to GHCR with `latest`, the short commit SHA, and the release version number (for example `1.0.1`). Release-please reads `.release-please-manifest.json` to track package versions, so keep that file in the repo root.
 
 Release tags follow the classic `vX.Y.Z` format. Downstream jobs, such as the Docker workflow, use that tag directly when naming images.
 


### PR DESCRIPTION
## Summary
- run docker builds only when source or build files change
- document the new filtered workflow

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684827d4388c832299b61aa6e53057a7