### PR TITLE
Update release build workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -31,7 +31,7 @@ on:
       - models/**
       - buttons/**
   release:
-    types: [created]
+    types: [published]
 
 permissions:
   contents: read
@@ -60,7 +60,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=pr
             type=sha,prefix=,format=short
-            type=semver,pattern={{version}},value=${{ github.ref_name }}
+            type=semver,pattern={{version}},value=${{ github.event.release.tag_name }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ These practices ensure that if you rename or remove a channel, or if you want to
 
 CI/CD and Releases
 
-GitHub Actions build and publish the Docker image whenever application code or build files change on `main` or in a pull request, or when a new release tag is created. Documentation or workflow tweaks won't trigger a new image. Each pull request gets its own `pr-N` image tag, letting you test the container before merging. Releases are handled by `release-please`, which opens a pull request proposing the next version. Once that PR is merged, GitHub tags the repo and the Docker workflow publishes images with `latest`, the short commit SHA, and the release version (for example `1.0.1`). Release-please stores version numbers in `.release-please-manifest.json`; the file shows up after the first release.
+GitHub Actions build and publish the Docker image whenever application code or build files change on `main` or in a pull request. When a release is published, the same workflow runs and pushes an image tagged with that version. Documentation or workflow tweaks won't trigger a new image. Each pull request gets its own `pr-N` tag so you can test before merging. `release-please` opens a pull request with the next version. After that PR merges, GitHub creates the release and the Docker workflow uploads images tagged `latest`, the short commit SHA, and the release number (for example `1.0.1`). Release-please stores the current version in `.release-please-manifest.json`.
 
 Release tags simply use `X.Y.Z`. Downstream jobs, including the Docker workflow, use that tag directly when naming images.
 


### PR DESCRIPTION
## Summary
- ensure Docker publishes on release publish
- document release publishing behavior

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848394dbfdc8322a8a6e44f581336eb