### PR TITLE
Centralize settings usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Pedro-Bot/
 
 1. **Slash Command**: `/matchmaking` (in `commands/matchmaking.js`):
    - Prompts the user for time selection, game code, description, etc.
-   - Creates a new message in the `#matchmaking` channel with an embed and two buttons (JOIN, LEAVE).
+   - Creates a new message in the configured matchmaking channel (default `#matchmaking`) with an embed and two buttons (JOIN, LEAVE).
    - Creates a new thread under that message for discussion.
    - Stores the lobby data in MongoDB (`Lobby` model).
    - Schedules a start time (using `node-schedule` in `index.js`) to mark the lobby as “started” and update the embed.
@@ -102,7 +102,7 @@ Pedro-Bot/
    - `helpers.js` within matchmaking builds or rebuilds the embed (`buildLobbyEmbed`), adding a small footer `(MATAC) The Mature Tactical Circkle`.
    - `updateLobbyEmbed` re-edits the original message.
 
-By keeping all “matchmaking” references (like channel name `#matchmaking`) and game-lobby logic in `commands/matchmaking/`, we avoid scattering that code throughout the project.
+By keeping all “matchmaking” references in `commands/matchmaking/` and using the `MATCHMAKING_CHANNEL` environment variable for the channel name, we avoid scattering that code throughout the project.
 
 ---
 
@@ -132,8 +132,9 @@ This system is minimal, but it can be expanded easily with leaderboards, cooldow
 | `CLIENT_ID`       | Your bot’s application client ID                                              |
 | `GUILD_ID`        | The server (guild) ID where you want to register commands                     |
 | `MONGO_URI`       | MongoDB connection string (e.g., `mongodb://mongodb:27017/pedro-bot`)         |
+| `MATCHMAKING_CHANNEL` | Name of the channel used for matchmaking lobbies (default `matchmaking`) |
 
-Note: Role mappings and the matchmaking mention role are configured with the `/settings` command and stored in MongoDB.
+Note: Role mappings and the matchmaking mention role are configured with the `/settings` command and stored in MongoDB. The matchmaking channel is defined with the `MATCHMAKING_CHANNEL` environment variable.
 **Usage**:  
 - In Docker Compose, set these as environment variables under `pedro-bot`.  
 - See `docker-compose.yml` for an example.

--- a/commands/levels/levelsManager.js
+++ b/commands/levels/levelsManager.js
@@ -28,8 +28,10 @@ async function incrementXP(message, xpToAdd) {
     }
 
     // Check if the channel is excluded
-    const excluded = await settingsService.getSetting('excludedChannels') || [];
-    if (excluded.includes(message.channel.id)) return;
+    if (!cachedExcludedChannels) {
+      await refreshExcludedChannelsCache();
+    }
+    if (cachedExcludedChannels.includes(message.channel.id)) return;
 
     // Cooldown check: skip if last message was less than 15 seconds ago
     if (userDoc.lastMessage && (Date.now() - userDoc.lastMessage.getTime()) < 15000) {

--- a/commands/levels/levelsManager.js
+++ b/commands/levels/levelsManager.js
@@ -28,7 +28,8 @@ async function incrementXP(message, xpToAdd) {
     }
 
     // Check if the channel is excluded
-    if (userDoc.excludedChannels.includes(message.channel.id)) return;
+    const excluded = await settingsService.getSetting('excludedChannels') || [];
+    if (excluded.includes(message.channel.id)) return;
 
     // Cooldown check: skip if last message was less than 15 seconds ago
     if (userDoc.lastMessage && (Date.now() - userDoc.lastMessage.getTime()) < 15000) {

--- a/commands/manageChannels.command.js
+++ b/commands/manageChannels.command.js
@@ -1,6 +1,6 @@
 // commands/manageChannels.command.js
 const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
-const UserXP = require('../models/UserXP');
+const settingsService = require('../services/settingsService');
 const { MessageFlags } = require('discord.js');
 const errorHandler = require('../utils/errorHandler');
 
@@ -35,24 +35,18 @@ module.exports = {
       const subcommand = interaction.options.getSubcommand();
       const channel = interaction.options.getChannel('channel');
 
-      let globalSettings = await UserXP.findById('globalSettings').exec();
-      if (!globalSettings) {
-        globalSettings = new UserXP({
-          _id: 'globalSettings',
-          excludedChannels: [],
-        });
-        await globalSettings.save();
-      }
+      let excludedChannels = await settingsService.getSetting('excludedChannels');
+      if (!Array.isArray(excludedChannels)) excludedChannels = [];
 
       if (subcommand === 'add') {
-        if (globalSettings.excludedChannels.includes(channel.id)) {
+        if (excludedChannels.includes(channel.id)) {
           await interaction.reply({
             content: `🔴 Channel <#${channel.id}> is already excluded.`,
             flags: MessageFlags.Ephemeral,
           });
         } else {
-          globalSettings.excludedChannels.push(channel.id);
-          await globalSettings.save();
+          excludedChannels.push(channel.id);
+          await settingsService.setSetting('excludedChannels', excludedChannels);
           await interaction.reply({
             content: `✅ Channel <#${channel.id}> has been added to the excluded list.`,
             flags: MessageFlags.Ephemeral,
@@ -60,14 +54,14 @@ module.exports = {
           console.log(`[ℹ️] ${interaction.user.tag} added channel ${channel.id} to excluded channels.`);
         }
       } else if (subcommand === 'remove') {
-        if (!globalSettings.excludedChannels.includes(channel.id)) {
+        if (!excludedChannels.includes(channel.id)) {
           await interaction.reply({
             content: `🔴 Channel <#${channel.id}> is not in the excluded list.`,
             flags: MessageFlags.Ephemeral,
           });
         } else {
-          globalSettings.excludedChannels = globalSettings.excludedChannels.filter(id => id !== channel.id);
-          await globalSettings.save();
+          excludedChannels = excludedChannels.filter(id => id !== channel.id);
+          await settingsService.setSetting('excludedChannels', excludedChannels);
           await interaction.reply({
             content: `✅ Channel <#${channel.id}> has been removed from the excluded list.`,
             flags: MessageFlags.Ephemeral,
@@ -75,13 +69,13 @@ module.exports = {
           console.log(`[ℹ️] ${interaction.user.tag} removed channel ${channel.id} from excluded channels.`);
         }
       } else if (subcommand === 'list') {
-        if (globalSettings.excludedChannels.length === 0) {
+        if (excludedChannels.length === 0) {
           await interaction.reply({
             content: '📋 No channels are currently excluded from XP tracking.',
             flags: MessageFlags.Ephemeral,
           });
         } else {
-          const channelList = globalSettings.excludedChannels.map(id => `<#${id}>`).join('\n');
+          const channelList = excludedChannels.map(id => `<#${id}>`).join('\n');
           await interaction.reply({
             content: `📋 **Excluded Channels:**\n${channelList}`,
             flags: MessageFlags.Ephemeral,

--- a/commands/matchmaking/matchmaking.command.js
+++ b/commands/matchmaking/matchmaking.command.js
@@ -114,11 +114,12 @@ module.exports = {
         ButtonManager.createButtonRow(['join', 'leave'])
       ];
 
-      // Send to #matchmaking
-      const matchmakingChannel = interaction.guild.channels.cache.find(ch => ch.name === 'matchmaking');
+      // Send to configured matchmaking channel
+      const channelName = process.env.MATCHMAKING_CHANNEL || 'matchmaking';
+      const matchmakingChannel = interaction.guild.channels.cache.find(ch => ch.name === channelName);
       if (!matchmakingChannel) {
         await interaction.editReply({
-          content: '❌ Error: Could not find a channel named #matchmaking.',
+          content: `❌ Error: Could not find a channel named #${channelName}.`,
           flags: MessageFlags.Ephemeral
         });
         return;


### PR DESCRIPTION
## Summary
- store excluded channels in the `Settings` collection
- load `MATCHMAKING_CHANNEL` from env instead of hardcoding the channel name
- mention new env var in docs

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68483bbd7f8c8322a9ec04322e0852d4