### PR TITLE
Fix 4-hour selection value

### DIFF
--- a/commands/matchmaking/matchmaking.command.js
+++ b/commands/matchmaking/matchmaking.command.js
@@ -20,7 +20,7 @@ module.exports = {
           { name: 'In 30 Minutes', value: '30_min'  },
           { name: 'In 1 Hour',     value: '1_hour'  },
           { name: 'In 2 Hours',    value: '2_hours' },
-          { name: 'In 4 Hours',    value: '2_hours' }
+          { name: 'In 4 Hours',    value: '4_hours' }
         )
     )
     .addStringOption(option =>


### PR DESCRIPTION
## Summary
- correct the slash command option for 'In 4 Hours'

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68483b900c98832287c60ec5f04b2a8b