### PR TITLE
feat: add env validation and health endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 DISCORD_TOKEN=your-discord-bot-token
 CLIENT_ID=your-client-id
 GUILD_ID=your-guild-id
+MONGO_URI=mongodb://mongodb:27017/pedro-bot
+# optional
+HEALTH_PORT=3000

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ Below is a detailed breakdown of the repository’s structure, how each componen
 3. [Leveling Feature](#leveling-feature)
 4. [Environment Variables](#environment-variables)
 5. [How to Run via Docker Compose](#how-to-run-via-docker-compose)
-6. [Adding New Features](#adding-new-features)
-7. [Reusing Functions and Avoiding Duplicates](#reusing-functions-and-avoiding-duplicates)
-8. [CI/CD and Releases](#cicd-and-releases)
+6. [Health Check](#health-check)
+7. [Adding New Features](#adding-new-features)
+8. [Reusing Functions and Avoiding Duplicates](#reusing-functions-and-avoiding-duplicates)
+9. [CI/CD and Releases](#cicd-and-releases)
 
 ---
 
@@ -103,6 +104,7 @@ Pedro-Bot/
    - `updateLobbyEmbed` re-edits the original message.
 
 By keeping all “matchmaking” references in `commands/matchmaking/` and using the `MATCHMAKING_CHANNEL` environment variable for the channel name, we avoid scattering that code throughout the project.
+| `HEALTH_PORT` | Port for the health endpoint (default `3000`)
 
 ---
 
@@ -133,9 +135,12 @@ This system is minimal, but it can be expanded easily with leaderboards, cooldow
 | `GUILD_ID`        | The server (guild) ID where you want to register commands                     |
 | `MONGO_URI`       | MongoDB connection string (e.g., `mongodb://mongodb:27017/pedro-bot`)         |
 | `MATCHMAKING_CHANNEL` | Name of the channel used for matchmaking lobbies (default `matchmaking`) |
+| `HEALTH_PORT` | Port for the health endpoint (default `3000`)
 
 Note: Role mappings and the matchmaking mention role are configured with the `/settings` command and stored in MongoDB. The matchmaking channel is defined with the `MATCHMAKING_CHANNEL` environment variable.
 **Usage**:  
+The application exits if any of the required variables are missing at startup.
+Docker secrets can be used to supply sensitive values like `DISCORD_TOKEN`.
 - In Docker Compose, set these as environment variables under `pedro-bot`.  
 - See `docker-compose.yml` for an example.
 
@@ -151,8 +156,9 @@ Note: Role mappings and the matchmaking mention role are configured with the `/s
      pedro-bot:
        build:
          context: .
-       environment:
-         - DISCORD_TOKEN=...
+    secrets:
+      - discord_token
+    environment:
          - CLIENT_ID=...
          - GUILD_ID=...
          - MONGO_URI=mongodb://mongodb:27017/pedro-bot
@@ -171,6 +177,10 @@ Note: Role mappings and the matchmaking mention role are configured with the `/s
 6. Your bot will connect to Discord, connect to Mongo, register slash commands, and start listening for messages.
 
 
+
+## Health Check
+
+The bot exposes `GET /health` on the port defined by `HEALTH_PORT` (defaults to `3000`). A response of `OK` indicates the service is up.
 
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,9 @@ services:
         target: /app/data
     restart: always
     pull_policy: build
+    secrets:
+      - discord_token
     environment:
-      - DISCORD_TOKEN=${DISCORD_TOKEN}
       - CLIENT_ID=${CLIENT_ID}
       - GUILD_ID=${GUILD_ID}
       - MONGO_URI=mongodb://mongodb:27017/pedro-bot
@@ -35,4 +36,8 @@ volumes:
   mongo_data:
 
 networks:
-  pedro-network:
+  pedro-network
+
+secrets:
+  discord_token:
+    file: ./secrets/discord_token

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 // index.js
 require('dotenv').config();
+require('./utils/envValidator')();
+require('./utils/healthServer')();
 const fs = require('fs');
 const path = require('path');
 const { Client, GatewayIntentBits, Collection, REST, Routes } = require('discord.js');

--- a/utils/envValidator.js
+++ b/utils/envValidator.js
@@ -1,0 +1,8 @@
+const required = ['DISCORD_TOKEN', 'CLIENT_ID', 'GUILD_ID', 'MONGO_URI'];
+module.exports = () => {
+  const missing = required.filter(k => !process.env[k]);
+  if (missing.length) {
+    console.error(`[❌] Missing environment variables: ${missing.join(', ')}`);
+    process.exit(1);
+  }
+};

--- a/utils/healthServer.js
+++ b/utils/healthServer.js
@@ -1,0 +1,14 @@
+const http = require('http');
+module.exports = () => {
+  const port = process.env.HEALTH_PORT || 3000;
+  const server = http.createServer((req, res) => {
+    if (req.url === '/health') {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('OK');
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  server.listen(port, () => console.log(`[ℹ️] Health server on ${port}`));
+};


### PR DESCRIPTION
## Summary
- validate required environment variables
- start a small health server
- support optional HEALTH_PORT and add .env example entries
- reference Docker secrets in compose and docs

## Testing
- `node -e "process.env.DISCORD_TOKEN='x';process.env.CLIENT_ID='1';process.env.GUILD_ID='1';process.env.MONGO_URI='m';require('./utils/envValidator')();console.log('ok');"`
- `node -e "require('./utils/healthServer')();setTimeout(()=>process.exit(),500);" &> /tmp/h.log & sleep 0.2 && curl -s http://localhost:3000/health`


------
https://chatgpt.com/codex/tasks/task_e_68485140196c83228cf4b2d47f372f70