### PR TITLE
Add profile and logging features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Pedro-Bot
 
-Pedro-Bot is a Discord bot with two core features:
+Pedro-Bot is a Discord bot with a handful of features:
 1. **Matchmaking** (organizing game lobbies with threads, join/leave buttons, etc.).
 2. **Leveling** (assigning XP for messages and granting roles when users level up).
+3. **Profiles** (view XP, level, and message stats with `/profile`).
+4. **Server Stats** (check member counts with `/serverstats`).
 
 Below is a detailed breakdown of the repository’s structure, how each component works, and how developers can extend it further.
 
@@ -12,11 +14,13 @@ Below is a detailed breakdown of the repository’s structure, how each componen
 1. [Project Structure](#project-structure)
 2. [Matchmaking Feature](#matchmaking-feature)
 3. [Leveling Feature](#leveling-feature)
-4. [Environment Variables](#environment-variables)
-5. [How to Run via Docker Compose](#how-to-run-via-docker-compose)
-6. [Adding New Features](#adding-new-features)
-7. [Reusing Functions and Avoiding Duplicates](#reusing-functions-and-avoiding-duplicates)
-8. [CI/CD and Releases](#cicd-and-releases)
+4. [Profiles](#profiles)
+5. [Server Statistics](#server-statistics)
+6. [Environment Variables](#environment-variables)
+7. [How to Run via Docker Compose](#how-to-run-via-docker-compose)
+8. [Adding New Features](#adding-new-features)
+9. [Reusing Functions and Avoiding Duplicates](#reusing-functions-and-avoiding-duplicates)
+10. [CI/CD and Releases](#cicd-and-releases)
 
 ---
 
@@ -30,12 +34,15 @@ Pedro-Bot/
 │   ├── admin/
 │   │   ├── reactionRoles.command.js
 │   │   ├── schedule.command.js
-│   │   └── settings.command.js
+│   │   ├── settings.command.js
+│   │   └── backup.command.js
 │   ├── levels/
-│   │   └── level.command.js
+│   │   ├── level.command.js
+│   │   └── profile.command.js
 │   ├── matchmaking/
 │   │   └── matchmaking.command.js
-│   └── manageChannels.command.js
+│   ├── manageChannels.command.js
+│   └── serverstats.command.js
 ├── config/
 │   └── constants.js
 ├── events/
@@ -56,7 +63,8 @@ Pedro-Bot/
 │   ├── lobbyService.js
 │   ├── scheduleService.js
 │   ├── settingsService.js
-│   └── userService.js
+│   ├── userService.js
+│   └── adminLogService.js
 ├── utils/
 │   ├── ButtonManager.js
 │   ├── database.js
@@ -76,6 +84,7 @@ Pedro-Bot/
   - `Lobby.js`: For matchmaking lobbies.
   - `UserXP.js`: For leveling / XP.
   - `ReactionRole.js`: For reaction roles.
+  - `AdminLog.js`: Records admin actions for auditing.
 - **`commands/matchmaking/`**: Self-contained logic for the matchmaking system.
 - **`commands/levels/`**: Self-contained logic for leveling. Contains:
   - `levelsManager.js`: Awarding XP and checking level-ups.
@@ -123,6 +132,14 @@ By keeping all “matchmaking” references in `commands/matchmaking/` and using
 This system is minimal, but it can be expanded easily with leaderboards, cooldowns, or advanced spam checks.
 
 ---
+
+## Profiles
+Use `/profile` to display a user\'s XP, level and message count.
+
+## Server Statistics
+The `/serverstats` command shows basic guild info such as member counts and channel totals.
+
+Admins can also back up or restore data using `/backup`.
 
 ## Environment Variables
 

--- a/commands/admin/backup.command.js
+++ b/commands/admin/backup.command.js
@@ -1,0 +1,61 @@
+// commands/admin/backup.command.js
+const { SlashCommandBuilder, PermissionsBitField, MessageFlags } = require('discord.js');
+const mongoose = require('mongoose');
+const fs = require('fs');
+const path = require('path');
+const errorHandler = require('../../utils/errorHandler');
+const adminLogService = require('../../services/adminLogService');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('backup')
+    .setDescription('Create or restore a database backup')
+    .setDefaultMemberPermissions(PermissionsBitField.Flags.Administrator)
+    .addSubcommand(sub =>
+      sub.setName('create').setDescription('Create a backup'))
+    .addSubcommand(sub =>
+      sub.setName('restore')
+        .setDescription('Restore from uploaded backup')
+        .addAttachmentOption(opt =>
+          opt.setName('file')
+            .setDescription('Backup JSON file')
+            .setRequired(true))),
+
+  async execute(interaction) {
+    const sub = interaction.options.getSubcommand();
+    try {
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+      if (sub === 'create') {
+        const collections = await mongoose.connection.db.collections();
+        const data = {};
+        for (const col of collections) {
+          const docs = await col.find({}).toArray();
+          data[col.collectionName] = docs;
+        }
+        const filePath = path.join('/tmp', `backup-${Date.now()}.json`);
+        fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+        await interaction.user.send({ files: [filePath] });
+        await interaction.editReply('✅ Backup created and sent to your DM.');
+        await adminLogService.logAction(interaction.user.id, 'backup create', { file: filePath });
+      } else if (sub === 'restore') {
+        const attachment = interaction.options.getAttachment('file');
+        if (!attachment) {
+          await interaction.editReply('❌ Please attach a backup file.');
+          return;
+        }
+        const res = await fetch(attachment.url);
+        const json = await res.json();
+        for (const [name, docs] of Object.entries(json)) {
+          const col = mongoose.connection.db.collection(name);
+          await col.deleteMany({});
+          if (docs.length) await col.insertMany(docs);
+        }
+        await interaction.editReply('✅ Backup restored.');
+        await adminLogService.logAction(interaction.user.id, 'backup restore', {});
+      }
+    } catch (error) {
+      errorHandler(error, 'Backup Command - execute');
+      await interaction.editReply('❌ Backup operation failed.');
+    }
+  },
+};

--- a/commands/admin/reactionRoles.command.js
+++ b/commands/admin/reactionRoles.command.js
@@ -3,6 +3,7 @@ const { SlashCommandBuilder, PermissionsBitField, ActionRowBuilder,MessageFlags,
 const ReactionRole = require('../../models/ReactionRole');
 const errorHandler = require('../../utils/errorHandler');
 const ButtonManager = require('../../utils/ButtonManager');
+const adminLogService = require('../../services/adminLogService');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -150,6 +151,7 @@ module.exports = {
                 });
 
                 console.log(`[✅] Created reaction role message with ID: ${message.id}`);
+                await adminLogService.logAction(interaction.user.id, 'reactionroles create', { message: message.id });
             } catch (error) {
                 errorHandler(error, 'ReactionRoles Command - create');
                 await interaction.reply({
@@ -191,6 +193,7 @@ module.exports = {
                 });
 
                 console.log(`[✅] Deleted reaction role message with ID: ${messageId}`);
+                await adminLogService.logAction(interaction.user.id, 'reactionroles delete', { message: messageId });
             } catch (error) {
                 errorHandler(error, 'ReactionRoles Command - delete');
                 await interaction.reply({

--- a/commands/admin/schedule.command.js
+++ b/commands/admin/schedule.command.js
@@ -3,6 +3,7 @@ const { SlashCommandBuilder, PermissionsBitField, MessageFlags } = require('disc
 const scheduleService = require('../../services/scheduleService');
 const scheduler = require('../../utils/scheduler');
 const errorHandler = require('../../utils/errorHandler');
+const adminLogService = require('../../services/adminLogService');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -64,12 +65,12 @@ module.exports = {
 
             try {
                 const schedule = await scheduleService.createSchedule(name, commandName, args, frequency);
-                // Schedule the command execution
                 scheduler.scheduleCommand(schedule);
                 await interaction.reply({
                     content: `✅ Schedule "${name}" has been created and scheduled.`,
                     flags: MessageFlags.Ephemeral,
                 });
+                await adminLogService.logAction(interaction.user.id, 'schedule create', { name, commandName, frequency });
             } catch (error) {
                 errorHandler(error, 'Schedule Command - create');
                 await interaction.reply({
@@ -101,6 +102,7 @@ module.exports = {
                     content: response,
                     flags: MessageFlags.Ephemeral,
                 });
+                await adminLogService.logAction(interaction.user.id, 'schedule list', {});
             } catch (error) {
                 errorHandler(error, 'Schedule Command - list');
                 await interaction.reply({
@@ -130,6 +132,7 @@ module.exports = {
                     content: `✅ Schedule "${name}" has been deleted and unscheduled.`,
                     flags: MessageFlags.Ephemeral,
                 });
+                await adminLogService.logAction(interaction.user.id, 'schedule delete', { name });
             } catch (error) {
                 errorHandler(error, 'Schedule Command - delete');
                 await interaction.reply({

--- a/commands/admin/settings.command.js
+++ b/commands/admin/settings.command.js
@@ -3,6 +3,7 @@ const { SlashCommandBuilder,MessageFlags, PermissionsBitField } = require('disco
 const settingsService = require('../../services/settingsService');
 const config = require('../../config/constants');
 const errorHandler = require('../../utils/errorHandler');
+const adminLogService = require('../../services/adminLogService');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -114,6 +115,7 @@ module.exports = {
         content: `✅ Role <@&${role.id}> has been set for Level ${level}.`,
         flags: MessageFlags.Ephemeral,
       });
+      await adminLogService.logAction(interaction.user.id, 'settings set-role', { level, role: role.id });
     }
 
     if (subcommand === 'remove-role') {
@@ -131,6 +133,7 @@ module.exports = {
         content: `✅ Role for Level ${level} has been removed.`,
         flags: MessageFlags.Ephemeral,
       });
+      await adminLogService.logAction(interaction.user.id, 'settings remove-role', { level });
     }
 
     if (subcommand === 'get-roles') {
@@ -151,6 +154,7 @@ module.exports = {
         content: response,
         flags: MessageFlags.Ephemeral,
       });
+      await adminLogService.logAction(interaction.user.id, 'settings get-roles', {});
     }
 
     // New subcommands for Notifications
@@ -169,6 +173,7 @@ module.exports = {
         content: `✅ Notification channel has been set to ${channel}.`,
         flags: MessageFlags.Ephemeral,
       });
+      await adminLogService.logAction(interaction.user.id, 'settings set-notification-channel', { channel: channel.id });
     }
 
     if (subcommand === 'toggle-welcome') {
@@ -178,6 +183,7 @@ module.exports = {
         content: `✅ Welcome messages have been ${enable ? 'enabled' : 'disabled'}.`,
         flags: MessageFlags.Ephemeral,
       });
+      await adminLogService.logAction(interaction.user.id, 'settings toggle-welcome', { enable });
     }
 
     if (subcommand === 'toggle-leave') {
@@ -187,6 +193,7 @@ module.exports = {
         content: `✅ Leave messages have been ${enable ? 'enabled' : 'disabled'}.`,
         flags: MessageFlags.Ephemeral,
       });
+      await adminLogService.logAction(interaction.user.id, 'settings toggle-leave', { enable });
     }
 
     if (subcommand === 'set-welcome-message') {
@@ -205,6 +212,7 @@ module.exports = {
         content: '✅ Welcome message has been updated.',
         flags: MessageFlags.Ephemeral,
       });
+      await adminLogService.logAction(interaction.user.id, 'settings set-welcome-message', {});
     }
 
     if (subcommand === 'set-leave-message') {
@@ -223,6 +231,7 @@ module.exports = {
         content: '✅ Leave message has been updated.',
         flags: MessageFlags.Ephemeral,
       });
+      await adminLogService.logAction(interaction.user.id, 'settings set-leave-message', {});
     }
   },
 

--- a/commands/levels/levelsManager.js
+++ b/commands/levels/levelsManager.js
@@ -38,8 +38,9 @@ async function incrementXP(message, xpToAdd) {
       return;
     }
 
-    // Update XP
+    // Update XP and message count
     userDoc.xp += xpToAdd;
+    userDoc.messageCount = (userDoc.messageCount || 0) + 1;
     userDoc.lastMessage = new Date();
 
     // Calculate new level

--- a/commands/manageChannels.command.js
+++ b/commands/manageChannels.command.js
@@ -3,6 +3,7 @@ const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
 const settingsService = require('../services/settingsService');
 const { MessageFlags } = require('discord.js');
 const errorHandler = require('../utils/errorHandler');
+const adminLogService = require('../services/adminLogService');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -52,6 +53,7 @@ module.exports = {
             flags: MessageFlags.Ephemeral,
           });
           console.log(`[ℹ️] ${interaction.user.tag} added channel ${channel.id} to excluded channels.`);
+          await adminLogService.logAction(interaction.user.id, 'managechannels add', { channel: channel.id });
         }
       } else if (subcommand === 'remove') {
         if (!excludedChannels.includes(channel.id)) {
@@ -67,6 +69,7 @@ module.exports = {
             flags: MessageFlags.Ephemeral,
           });
           console.log(`[ℹ️] ${interaction.user.tag} removed channel ${channel.id} from excluded channels.`);
+          await adminLogService.logAction(interaction.user.id, 'managechannels remove', { channel: channel.id });
         }
       } else if (subcommand === 'list') {
         if (excludedChannels.length === 0) {
@@ -80,6 +83,7 @@ module.exports = {
             content: `📋 **Excluded Channels:**\n${channelList}`,
             flags: MessageFlags.Ephemeral,
           });
+          await adminLogService.logAction(interaction.user.id, 'managechannels list', {});
         }
       }
     } catch (error) {

--- a/commands/profile.command.js
+++ b/commands/profile.command.js
@@ -1,0 +1,35 @@
+// commands/profile.command.js
+const { SlashCommandBuilder, MessageFlags } = require('discord.js');
+const userService = require('../services/userService');
+const errorHandler = require('../utils/errorHandler');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('profile')
+    .setDescription('Show user profile statistics')
+    .addUserOption(option =>
+      option.setName('user')
+        .setDescription('User to check')
+        .setRequired(false)),
+
+  async execute(interaction) {
+    try {
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+      const user = interaction.options.getUser('user') || interaction.user;
+      const userDoc = await userService.getUser(user.id) || { xp: 0, level: 0, messageCount: 0 };
+      await interaction.editReply({
+        content: `**${user.username}'s Profile**\n` +
+                 `Level: ${userDoc.level}\n` +
+                 `XP: ${userDoc.xp}\n` +
+                 `Messages: ${userDoc.messageCount || 0}`,
+        flags: MessageFlags.Ephemeral,
+      });
+    } catch (error) {
+      errorHandler(error, 'Profile Command - execute');
+      await interaction.reply({
+        content: '❌ Error fetching profile.',
+        flags: MessageFlags.Ephemeral,
+      }).catch(err => errorHandler(err, 'Profile Command - reply error'));
+    }
+  },
+};

--- a/commands/serverstats.command.js
+++ b/commands/serverstats.command.js
@@ -1,0 +1,33 @@
+// commands/serverstats.command.js
+const { SlashCommandBuilder, MessageFlags } = require('discord.js');
+const errorHandler = require('../utils/errorHandler');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('serverstats')
+    .setDescription('Display basic server statistics'),
+
+  async execute(interaction) {
+    try {
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+      const { guild } = interaction;
+      const members = await guild.members.fetch();
+      const total = members.size;
+      const bots = members.filter(m => m.user.bot).size;
+      const humans = total - bots;
+      const roles = guild.roles.cache.size;
+      const channels = guild.channels.cache.size;
+      await interaction.editReply({
+        content: `**Server Stats**\nMembers: ${total} (Humans: ${humans}, Bots: ${bots})\n` +
+                 `Roles: ${roles}\nChannels: ${channels}`,
+        flags: MessageFlags.Ephemeral,
+      });
+    } catch (error) {
+      errorHandler(error, 'ServerStats Command - execute');
+      await interaction.reply({
+        content: '❌ Error fetching server stats.',
+        flags: MessageFlags.Ephemeral,
+      }).catch(err => errorHandler(err, 'ServerStats Command - reply error'));
+    }
+  },
+};

--- a/models/AdminLog.js
+++ b/models/AdminLog.js
@@ -1,0 +1,12 @@
+const mongoose = require('../utils/database');
+
+const adminLogSchema = new mongoose.Schema({
+  action: { type: String, required: true },
+  userId: { type: String, required: true },
+  timestamp: { type: Date, default: Date.now },
+  details: { type: Object, default: {} },
+}, {
+  versionKey: false,
+});
+
+module.exports = mongoose.model('AdminLog', adminLogSchema);

--- a/models/UserXP.js
+++ b/models/UserXP.js
@@ -6,6 +6,7 @@ const userXPSchema = new mongoose.Schema({
   xp: { type: Number, default: 0 },
   level: { type: Number, default: 0 },
   lastMessage: { type: Date, default: null },
+  messageCount: { type: Number, default: 0 },
   excludedChannels: { type: [String], default: [] },
 }, {
   versionKey: false,

--- a/services/adminLogService.js
+++ b/services/adminLogService.js
@@ -1,0 +1,12 @@
+const AdminLog = require('../models/AdminLog');
+const errorHandler = require('../utils/errorHandler');
+
+module.exports = {
+  async logAction(userId, action, details = {}) {
+    try {
+      await AdminLog.create({ userId, action, details });
+    } catch (error) {
+      errorHandler(error, 'AdminLog Service - logAction');
+    }
+  },
+};


### PR DESCRIPTION
## Summary
- track message counts for users
- log admin activity in Mongo
- add `/profile`, `/serverstats`, and `/backup` commands
- expose new services and models in README
- document new commands and features

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684851b15c588322bd1e2916781411e9