### PR TITLE
Add audit logging and user stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,16 @@ Below is a detailed breakdown of the repository’s structure, how each componen
 1. [Project Structure](#project-structure)
 2. [Matchmaking Feature](#matchmaking-feature)
 3. [Leveling Feature](#leveling-feature)
-4. [Environment Variables](#environment-variables)
-5. [How to Run via Docker Compose](#how-to-run-via-docker-compose)
-6. [Health Check](#health-check)
-7. [Adding New Features](#adding-new-features)
-8. [Reusing Functions and Avoiding Duplicates](#reusing-functions-and-avoiding-duplicates)
-9. [CI/CD and Releases](#cicd-and-releases)
+4. [User Profiles](#user-profiles)
+5. [Server Statistics](#server-statistics)
+6. [Backup and Restore](#backup-and-restore)
+7. [Admin Audit Logs](#admin-audit-logs)
+8. [Environment Variables](#environment-variables)
+9. [How to Run via Docker Compose](#how-to-run-via-docker-compose)
+10. [Health Check](#health-check)
+11. [Adding New Features](#adding-new-features)
+12. [Reusing Functions and Avoiding Duplicates](#reusing-functions-and-avoiding-duplicates)
+13. [CI/CD and Releases](#cicd-and-releases)
 
 ---
 
@@ -131,6 +135,22 @@ By keeping all “matchmaking” references in `commands/matchmaking/` and using
 This system is minimal, but it can be expanded easily with leaderboards, cooldowns, or advanced spam checks.
 
 ---
+
+## User Profiles
+
+Use `/profile` to see your level, XP, and rank. The command reads from the same `UserXP` collection used by the leveling system.
+
+## Server Statistics
+
+`/serverstats` shows total members, how many users have XP records, the number of active lobbies, and how many scheduled commands are defined.
+
+## Backup and Restore
+
+Admins can run `/backup create` to save the database to `backups/`. Use `/backup restore file:<path>` to restore from a saved file.
+
+## Admin Audit Logs
+
+Every admin command writes a record to MongoDB. Query the `AuditLog` collection to review changes.
 
 ## Environment Variables
 

--- a/commands/admin/backup.command.js
+++ b/commands/admin/backup.command.js
@@ -1,0 +1,46 @@
+const { SlashCommandBuilder, PermissionsBitField, MessageFlags } = require('discord.js');
+const backupService = require('../../services/backupService');
+const auditService = require('../../services/auditService');
+const errorHandler = require('../../utils/errorHandler');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('backup')
+    .setDescription('Create or restore a backup')
+    .setDefaultMemberPermissions(PermissionsBitField.Flags.Administrator)
+    .addSubcommand(sc => sc.setName('create').setDescription('Create a backup'))
+    .addSubcommand(sc =>
+      sc.setName('restore')
+        .setDescription('Restore from a backup')
+        .addStringOption(o =>
+          o.setName('file')
+            .setDescription('Backup file path')
+            .setRequired(true))),
+
+  async execute(interaction) {
+    const subcommand = interaction.options.getSubcommand();
+
+    if (subcommand === 'create') {
+      try {
+        const file = await backupService.createBackup();
+        await auditService.logAction(interaction.user.id, 'backup:create', { file });
+        await interaction.reply({ content: `✅ Backup created at ${file}`, flags: MessageFlags.Ephemeral });
+      } catch (error) {
+        errorHandler(error, 'Backup Command - create');
+        await interaction.reply({ content: '❌ Error creating backup.', flags: MessageFlags.Ephemeral });
+      }
+    }
+
+    if (subcommand === 'restore') {
+      const file = interaction.options.getString('file');
+      try {
+        await backupService.restoreBackup(file);
+        await auditService.logAction(interaction.user.id, 'backup:restore', { file });
+        await interaction.reply({ content: '✅ Backup restored.', flags: MessageFlags.Ephemeral });
+      } catch (error) {
+        errorHandler(error, 'Backup Command - restore');
+        await interaction.reply({ content: '❌ Error restoring backup.', flags: MessageFlags.Ephemeral });
+      }
+    }
+  },
+};

--- a/commands/admin/reactionRoles.command.js
+++ b/commands/admin/reactionRoles.command.js
@@ -3,6 +3,7 @@ const { SlashCommandBuilder, PermissionsBitField, ActionRowBuilder,MessageFlags,
 const ReactionRole = require('../../models/ReactionRole');
 const errorHandler = require('../../utils/errorHandler');
 const ButtonManager = require('../../utils/ButtonManager');
+const auditService = require('../../services/auditService');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -143,7 +144,7 @@ module.exports = {
                 });
 
                 await reactionRole.save();
-
+                await auditService.logAction(interaction.user.id, 'reactionroles:create', { messageId: message.id });
                 await interaction.reply({
                     content: '✅ Reaction role message has been created successfully.',
                     flags: MessageFlags.Ephemeral,
@@ -184,7 +185,7 @@ module.exports = {
 
                 // Remove from database
                 await ReactionRole.deleteOne({ messageId }).exec();
-
+                await auditService.logAction(interaction.user.id, 'reactionroles:delete', { messageId });
                 await interaction.reply({
                     content: `✅ Reaction role message with ID "${messageId}" has been deleted.`,
                     flags: MessageFlags.Ephemeral,

--- a/commands/admin/schedule.command.js
+++ b/commands/admin/schedule.command.js
@@ -3,6 +3,7 @@ const { SlashCommandBuilder, PermissionsBitField, MessageFlags } = require('disc
 const scheduleService = require('../../services/scheduleService');
 const scheduler = require('../../utils/scheduler');
 const errorHandler = require('../../utils/errorHandler');
+const auditService = require('../../services/auditService');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -64,8 +65,8 @@ module.exports = {
 
             try {
                 const schedule = await scheduleService.createSchedule(name, commandName, args, frequency);
-                // Schedule the command execution
                 scheduler.scheduleCommand(schedule);
+                await auditService.logAction(interaction.user.id, 'schedule:create', { name, commandName, frequency });
                 await interaction.reply({
                     content: `✅ Schedule "${name}" has been created and scheduled.`,
                     flags: MessageFlags.Ephemeral,
@@ -126,6 +127,7 @@ module.exports = {
                 scheduler.unscheduleCommand(name);
 
                 await scheduleService.deleteSchedule(name);
+                await auditService.logAction(interaction.user.id, 'schedule:delete', { name });
                 await interaction.reply({
                     content: `✅ Schedule "${name}" has been deleted and unscheduled.`,
                     flags: MessageFlags.Ephemeral,

--- a/commands/admin/settings.command.js
+++ b/commands/admin/settings.command.js
@@ -3,6 +3,7 @@ const { SlashCommandBuilder,MessageFlags, PermissionsBitField } = require('disco
 const settingsService = require('../../services/settingsService');
 const config = require('../../config/constants');
 const errorHandler = require('../../utils/errorHandler');
+const auditService = require('../../services/auditService');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -110,6 +111,7 @@ module.exports = {
       }
 
       await settingsService.setRoleForLevel(level, role.id);
+      await auditService.logAction(interaction.user.id, 'settings:set-role', { level, role: role.id });
       return interaction.reply({
         content: `✅ Role <@&${role.id}> has been set for Level ${level}.`,
         flags: MessageFlags.Ephemeral,
@@ -127,6 +129,7 @@ module.exports = {
       }
 
       await settingsService.setRoleForLevel(level, null);
+      await auditService.logAction(interaction.user.id, 'settings:remove-role', { level });
       return interaction.reply({
         content: `✅ Role for Level ${level} has been removed.`,
         flags: MessageFlags.Ephemeral,
@@ -165,6 +168,7 @@ module.exports = {
       }
 
       await settingsService.setSetting('notificationChannelId', channel.id);
+      await auditService.logAction(interaction.user.id, 'settings:set-notification-channel', { channel: channel.id });
       return interaction.reply({
         content: `✅ Notification channel has been set to ${channel}.`,
         flags: MessageFlags.Ephemeral,
@@ -174,6 +178,7 @@ module.exports = {
     if (subcommand === 'toggle-welcome') {
       const enable = interaction.options.getBoolean('enable');
       await settingsService.setSetting('welcomeEnabled', enable);
+      await auditService.logAction(interaction.user.id, 'settings:toggle-welcome', { enable });
       return interaction.reply({
         content: `✅ Welcome messages have been ${enable ? 'enabled' : 'disabled'}.`,
         flags: MessageFlags.Ephemeral,
@@ -183,6 +188,7 @@ module.exports = {
     if (subcommand === 'toggle-leave') {
       const enable = interaction.options.getBoolean('enable');
       await settingsService.setSetting('leaveEnabled', enable);
+      await auditService.logAction(interaction.user.id, 'settings:toggle-leave', { enable });
       return interaction.reply({
         content: `✅ Leave messages have been ${enable ? 'enabled' : 'disabled'}.`,
         flags: MessageFlags.Ephemeral,
@@ -201,6 +207,7 @@ module.exports = {
       }
 
       await settingsService.setSetting('welcomeMessage', message);
+      await auditService.logAction(interaction.user.id, 'settings:set-welcome-message');
       return interaction.reply({
         content: '✅ Welcome message has been updated.',
         flags: MessageFlags.Ephemeral,
@@ -219,6 +226,7 @@ module.exports = {
       }
 
       await settingsService.setSetting('leaveMessage', message);
+      await auditService.logAction(interaction.user.id, 'settings:set-leave-message');
       return interaction.reply({
         content: '✅ Leave message has been updated.',
         flags: MessageFlags.Ephemeral,

--- a/commands/profile.command.js
+++ b/commands/profile.command.js
@@ -1,0 +1,36 @@
+const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
+const userService = require('../services/userService');
+const errorHandler = require('../utils/errorHandler');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('profile')
+    .setDescription('Show your user profile'),
+
+  async execute(interaction) {
+    try {
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+      const userId = interaction.user.id;
+      const userDoc = await userService.getUser(userId) || { xp: 0, level: 0 };
+      const rank = await userService.getUserRank(userId);
+
+      const embed = new EmbedBuilder()
+        .setTitle(`${interaction.user.username}'s Profile`)
+        .addFields(
+          { name: 'Level', value: String(userDoc.level), inline: true },
+          { name: 'XP', value: String(userDoc.xp), inline: true },
+          { name: 'Rank', value: `#${rank}`, inline: true },
+        )
+        .setThumbnail(interaction.user.displayAvatarURL());
+
+      await interaction.editReply({ embeds: [embed], flags: MessageFlags.Ephemeral });
+    } catch (error) {
+      errorHandler(error, 'Profile Command - execute');
+      if (interaction.deferred) {
+        await interaction.editReply({ content: '❌ Error fetching profile.', flags: MessageFlags.Ephemeral });
+      } else {
+        await interaction.reply({ content: '❌ Error fetching profile.', flags: MessageFlags.Ephemeral });
+      }
+    }
+  },
+};

--- a/commands/serverstats.command.js
+++ b/commands/serverstats.command.js
@@ -1,0 +1,39 @@
+const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
+const userService = require('../services/userService');
+const lobbyService = require('../services/lobbyService');
+const scheduleService = require('../services/scheduleService');
+const errorHandler = require('../utils/errorHandler');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('serverstats')
+    .setDescription('Show server statistics'),
+
+  async execute(interaction) {
+    try {
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+      const memberCount = interaction.guild.memberCount;
+      const activeLobbies = await lobbyService.getActiveLobbyCount();
+      const userCount = await userService.getUserCount();
+      const scheduleCount = await scheduleService.getScheduleCount();
+
+      const embed = new EmbedBuilder()
+        .setTitle('Server Statistics')
+        .addFields(
+          { name: 'Members', value: String(memberCount), inline: true },
+          { name: 'Registered Users', value: String(userCount), inline: true },
+          { name: 'Active Lobbies', value: String(activeLobbies), inline: true },
+          { name: 'Scheduled Commands', value: String(scheduleCount), inline: true },
+        );
+
+      await interaction.editReply({ embeds: [embed], flags: MessageFlags.Ephemeral });
+    } catch (error) {
+      errorHandler(error, 'ServerStats Command - execute');
+      if (interaction.deferred) {
+        await interaction.editReply({ content: '❌ Error fetching server stats.', flags: MessageFlags.Ephemeral });
+      } else {
+        await interaction.reply({ content: '❌ Error fetching server stats.', flags: MessageFlags.Ephemeral });
+      }
+    }
+  },
+};

--- a/models/AuditLog.js
+++ b/models/AuditLog.js
@@ -1,0 +1,12 @@
+const mongoose = require('../utils/database');
+
+const auditLogSchema = new mongoose.Schema({
+  adminId: { type: String, required: true },
+  action: { type: String, required: true },
+  details: { type: Object, default: {} },
+  createdAt: { type: Date, default: Date.now },
+}, {
+  versionKey: false,
+});
+
+module.exports = mongoose.model('AuditLog', auditLogSchema);

--- a/services/auditService.js
+++ b/services/auditService.js
@@ -1,0 +1,28 @@
+const AuditLog = require('../models/AuditLog');
+const errorHandler = require('../utils/errorHandler');
+
+module.exports = {
+  async logAction(adminId, action, details = {}) {
+    try {
+      const log = new AuditLog({ adminId, action, details });
+      await log.save();
+      return log;
+    } catch (error) {
+      errorHandler(error, 'Audit Service - logAction');
+      throw error;
+    }
+  },
+
+  async getLogs(limit = 50, skip = 0) {
+    try {
+      return await AuditLog.find()
+        .sort({ createdAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .exec();
+    } catch (error) {
+      errorHandler(error, 'Audit Service - getLogs');
+      return [];
+    }
+  },
+};

--- a/services/backupService.js
+++ b/services/backupService.js
@@ -1,0 +1,50 @@
+const fs = require('fs/promises');
+const path = require('path');
+const Settings = require('../models/Settings');
+const ReactionRole = require('../models/ReactionRole');
+const Lobby = require('../models/Lobby');
+const Schedule = require('../models/Schedule');
+const UserXP = require('../models/UserXP');
+const errorHandler = require('../utils/errorHandler');
+
+module.exports = {
+  async createBackup() {
+    try {
+      const backup = {
+        settings: await Settings.find().lean(),
+        reactionRoles: await ReactionRole.find().lean(),
+        lobbies: await Lobby.find().lean(),
+        schedules: await Schedule.find().lean(),
+        userXP: await UserXP.find().lean(),
+      };
+      await fs.mkdir('backups', { recursive: true });
+      const filePath = path.join('backups', `backup-${Date.now()}.json`);
+      await fs.writeFile(filePath, JSON.stringify(backup, null, 2));
+      return filePath;
+    } catch (error) {
+      errorHandler(error, 'Backup Service - createBackup');
+      throw error;
+    }
+  },
+
+  async restoreBackup(file) {
+    try {
+      const data = JSON.parse(await fs.readFile(file, 'utf8'));
+      await Promise.all([
+        Settings.deleteMany({}),
+        ReactionRole.deleteMany({}),
+        Lobby.deleteMany({}),
+        Schedule.deleteMany({}),
+        UserXP.deleteMany({}),
+      ]);
+      if (data.settings) await Settings.insertMany(data.settings);
+      if (data.reactionRoles) await ReactionRole.insertMany(data.reactionRoles);
+      if (data.lobbies) await Lobby.insertMany(data.lobbies);
+      if (data.schedules) await Schedule.insertMany(data.schedules);
+      if (data.userXP) await UserXP.insertMany(data.userXP);
+    } catch (error) {
+      errorHandler(error, 'Backup Service - restoreBackup');
+      throw error;
+    }
+  },
+};

--- a/services/lobbyService.js
+++ b/services/lobbyService.js
@@ -49,4 +49,13 @@ module.exports = {
       throw error;
     }
   },
+
+  async getActiveLobbyCount() {
+    try {
+      return await Lobby.countDocuments({ started: false }).exec();
+    } catch (error) {
+      errorHandler(error, 'Lobby Service - getActiveLobbyCount');
+      return 0;
+    }
+  },
 };

--- a/services/scheduleService.js
+++ b/services/scheduleService.js
@@ -67,4 +67,13 @@ module.exports = {
       throw error;
     }
   },
+
+  async getScheduleCount() {
+    try {
+      return await Schedule.countDocuments().exec();
+    } catch (error) {
+      errorHandler(error, 'Schedule Service - getScheduleCount');
+      return 0;
+    }
+  },
 };

--- a/services/userService.js
+++ b/services/userService.js
@@ -81,4 +81,16 @@ module.exports = {
       return 0;
     }
   },
+
+  async getUserRank(id) {
+    try {
+      const user = await UserXP.findById(id).exec();
+      if (!user) return 0;
+      const better = await UserXP.countDocuments({ xp: { $gt: user.xp } }).exec();
+      return better + 1;
+    } catch (error) {
+      errorHandler(error, 'User Service - getUserRank');
+      return 0;
+    }
+  },
 };


### PR DESCRIPTION
## Summary
- add AuditLog model and auditService
- implement backup command for admins
- add `/profile` and `/serverstats` commands
- log admin actions in admin commands
- support lobby and schedule counting
- document profile, stats, backups and audits

## Testing
- `npm audit --audit-level=moderate`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848546e1d848322802fc76979304867