### PR TITLE
Matchmaking improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,12 @@ Pedro-Bot/
 ## Matchmaking Feature
 
 1. **Slash Command**: `/matchmaking` (in `commands/matchmaking.js`):
-   - Prompts the user for time selection, game code, description, etc.
+   - Prompts the user for time, game code, optional template, slot count, and description.
    - Creates a new message in the configured matchmaking channel (default `#matchmaking`) with an embed and two buttons (JOIN, LEAVE).
    - Creates a new thread under that message for discussion.
    - Stores the lobby data in MongoDB (`Lobby` model).
    - Schedules a start time with `scheduler.scheduleLobbyStart` to mark the lobby as started and update the embed.
+   - Also schedules automatic cleanup six hours after the start time, archiving the lobby into `LobbyHistory`.
    - The role mentioned in the embed is configured with `/settings set-matchmaking-role` and stored in MongoDB.
 
 2. **Join/Leave Logic**:
@@ -100,8 +101,13 @@ Pedro-Bot/
    - If the button ID is “join” or “leave,” it updates the corresponding lobby’s data (stored in Mongo), and edits the embed to reflect the updated users.
 
 3. **Embed Updates**:
-   - `helpers.js` within matchmaking builds or rebuilds the embed (`buildLobbyEmbed`), adding a small footer `(MATAC) The Mature Tactical Circkle`.
-   - `updateLobbyEmbed` re-edits the original message.
+ - `helpers.js` within matchmaking builds or rebuilds the embed (`buildLobbyEmbed`), adding a small footer `(MATAC) The Mature Tactical Circkle`.
+  - `updateLobbyEmbed` re-edits the original message.
+  - Full lobbies prevent additional joins based on the configured slot count.
+
+4. **History & Recurring Lobbies**:
+   - Finished lobbies are archived automatically and can be counted with `historyService.getLobbyStats()`.
+   - Use `/schedule` to create recurring lobbies by scheduling the `/matchmaking` command.
 
 By keeping all “matchmaking” references in `commands/matchmaking/` and using the `MATCHMAKING_CHANNEL` environment variable for the channel name, we avoid scattering that code throughout the project.
 | `HEALTH_PORT` | Port for the health endpoint (default `3000`)

--- a/buttons/join.js
+++ b/buttons/join.js
@@ -35,6 +35,15 @@ module.exports = {
         return;
       }
 
+      if (lobbyData.joinedUsers.length >= lobbyData.totalSlots) {
+        await interaction.reply({
+          content: '🔴 This lobby is full.',
+          flags: MessageFlags.Ephemeral,
+          allowedMentions: { parse: ['roles'] },
+        });
+        return;
+      }
+
       // Add user to lobby
       lobbyData.joinedUsers.push(username);
       lobbyData.joinedUserIds.push(userId);

--- a/config/constants.js
+++ b/config/constants.js
@@ -1,18 +1,19 @@
 // config/constants.js
 module.exports = {
-    BUTTON_IDS: {
-      JOIN: 'join',
-      LEAVE: 'leave',
-      // Add more button IDs as needed
-    },
+  BUTTON_IDS: {
+    JOIN: 'join',
+    LEAVE: 'leave',
+  },
   PERMISSIONS: {
     ADMINISTRATOR: 'ADMINISTRATOR',
-    // Add more permissions as needed
   },
   XP_MULTIPLIERS: {
     MESSAGE: 1,
     DAILY: 2,
     WEEKLY: 5,
   },
+  GAME_TEMPLATES: {
+    arma3: { slots: 10, description: 'Standard Arma 3 session' },
+    squad: { slots: 8, description: 'Standard Squad session' },
+  },
 };
-  

--- a/models/LobbyHistory.js
+++ b/models/LobbyHistory.js
@@ -1,0 +1,18 @@
+// models/LobbyHistory.js
+const mongoose = require('../utils/database');
+
+const lobbyHistorySchema = new mongoose.Schema({
+  lobbyId: String,
+  gameCode: String,
+  creator: String,
+  tags: String,
+  joinedUsers: [String],
+  totalSlots: Number,
+  description: String,
+  matchTime: Date,
+  endedAt: Date,
+}, {
+  versionKey: false,
+});
+
+module.exports = mongoose.model('LobbyHistory', lobbyHistorySchema);

--- a/services/historyService.js
+++ b/services/historyService.js
@@ -1,0 +1,26 @@
+// services/historyService.js
+const LobbyHistory = require('../models/LobbyHistory');
+const errorHandler = require('../utils/errorHandler');
+
+module.exports = {
+  async recordLobby(data) {
+    try {
+      const history = new LobbyHistory(data);
+      await history.save();
+      return history;
+    } catch (error) {
+      errorHandler(error, 'History Service - recordLobby');
+      throw error;
+    }
+  },
+
+  async getLobbyStats() {
+    try {
+      const total = await LobbyHistory.countDocuments().exec();
+      return { total };
+    } catch (error) {
+      errorHandler(error, 'History Service - getLobbyStats');
+      return { total: 0 };
+    }
+  },
+};

--- a/utils/database.js
+++ b/utils/database.js
@@ -1,6 +1,5 @@
 // utils/database.js
 const mongoose = require('mongoose');
-const config = require('../config/constants');
 const errorHandler = require('./errorHandler');
 
 const MONGO_URI = process.env.MONGO_URI;
@@ -13,7 +12,6 @@ mongoose.connect(MONGO_URI)
     errorHandler(err, 'MongoDB Connection');
   });
 
-// Handle Mongoose Events
 mongoose.connection.on('connected', () => {
   console.log('Mongoose connected to MongoDB.');
 });
@@ -26,7 +24,6 @@ mongoose.connection.on('disconnected', () => {
   console.log('Mongoose disconnected from MongoDB.');
 });
 
-// Optional: Handle process termination
 process.on('SIGINT', async () => {
   await mongoose.connection.close();
   console.log('Mongoose connection closed due to app termination.');


### PR DESCRIPTION
## Summary
- support game templates and custom slot counts
- clean up old lobbies automatically
- keep lobby history for stats
- mention new options in the docs

## Testing
- `node --check commands/matchmaking/matchmaking.command.js`
- `node --check utils/scheduler.js`
- `node --check services/historyService.js`
- `node --check buttons/join.js`


------
https://chatgpt.com/codex/tasks/task_e_684854f879248322897ccbf0afda2984