### PR TITLE
fix(ci): use mongo 7.0 in tests

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 10
     services:
       mongodb:
-        image: mongo:8.0
+        image: mongo:7.0
         ports:
           - 27017:27017
         options: >-

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Docker secrets can be used to supply sensitive values like `DISCORD_TOKEN`.
        depends_on:
          - mongodb
      mongodb:
-       image: mongo:8.0
+       image: mongo:7.0
        volumes:
          - mongo_data:/data/db
    volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
 
   mongodb:
     container_name: pedro-bot-mongo
-    image: mongo:8.0
+    image: mongo:7.0
     restart: always
     volumes:
       - mongo_data:/data/db


### PR DESCRIPTION
## Summary
- use MongoDB 7.0 for docker compose
- use MongoDB 7.0 in CI workflow
- update README example

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684863ad036483229965712e83b40c4e